### PR TITLE
Delete .github/CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-* @MatthewJMacphail


### PR DESCRIPTION
## What & Why?
As we set up the organisation properly this file is no longer needed.

## Checklist
N/A

